### PR TITLE
Fix go_get attribute in dependencies docs

### DIFF
--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -120,7 +120,7 @@
     go_get(
         name = 'my_library',
         get = "github.com/me/my_library",
-        version = "1.0.0",
+        revision = "v1.0.0",
     )
         </code>
       </pre>


### PR DESCRIPTION
- https://please.build/dependencies.html currently states the following:
`
go_get(
        name = "my_library",
        get = "github.com/me/my_library",
        version = "1.0.0",
)
`
go_get does not use the version attribute, and uses revision instead.